### PR TITLE
Update workflow trigger to on push

### DIFF
--- a/.github/workflows/version-calculate.yml
+++ b/.github/workflows/version-calculate.yml
@@ -1,9 +1,11 @@
 name: Calculate Version
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [master]
+  push:
+    branches: ["master"]
+    
+permissions:
+  contents: write
 
 jobs:
   calculate:


### PR DESCRIPTION
Change the version calculation workflow to trigger on push events to the master branch instead of on pull request closure. This simplifies the trigger condition and ensures it runs reliably after merges. Added write permissions to allow the action to commit the updated version file.