### PR TITLE
Install xmllint dependency in workflow

### DIFF
--- a/.github/workflows/version-calculate.yml
+++ b/.github/workflows/version-calculate.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install xmllint
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
       - name: Read current version
         id: current
         run: |


### PR DESCRIPTION
Add a step to the version calculation workflow to explicitly install `libxml2-utils` which provides `xmllint`. This ensures the tool is available in the runner environment.