### PR TITLE
Automate push for version bump in CI

### DIFF
--- a/.github/workflows/version-calculate.yml
+++ b/.github/workflows/version-calculate.yml
@@ -1,16 +1,17 @@
 name: Calculate Version
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches: ["master"]
-    
+
 permissions:
   contents: write
 
 jobs:
   calculate:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-
     outputs:
       version: ${{ steps.version.outputs.next }}
 
@@ -18,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install xmllint
-        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils xmlstarlet jq
 
       - name: Read current version
         id: current
@@ -65,3 +66,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pom.xml
           git commit -m "ci: bump version to $NEXT"
+          git push


### PR DESCRIPTION
The CI workflow now automatically pushes the updated pom.xml to the master branch after a version bump.