### PR TITLE
Add fluent state transitions to ViewState

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .idea/
 target/
+/nbproject/

--- a/src/main/java/com/github/idelstak/ikonx/Pack.java
+++ b/src/main/java/com/github/idelstak/ikonx/Pack.java
@@ -88,50 +88,50 @@ public enum Pack {
     MATERIAL_DESIGN("Material Design", MaterialDesign.values()),
     FONT_AWESOME("Font Awesome", FontAwesome.values()),
     FONT_AWESOME_5("Font Awesome 5", Stream.concat(
-            Stream.concat(
-                    Arrays.stream(FontAwesomeBrands.values()).map(brands -> (Ikon) brands),
-                    Arrays.stream(FontAwesomeRegular.values()).map(regular -> (Ikon) regular)
-            ),
-            Arrays.stream(FontAwesomeSolid.values()).map(solid -> (Ikon) solid)
+      Stream.concat(
+        Arrays.stream(FontAwesomeBrands.values()).map(brands -> (Ikon) brands),
+        Arrays.stream(FontAwesomeRegular.values()).map(regular -> (Ikon) regular)
+      ),
+      Arrays.stream(FontAwesomeSolid.values()).map(solid -> (Ikon) solid)
     ).toArray(Ikon[]::new)),
     EVA_ICONS("Eva Icons", Evaicons.values()),
     ION_ICONS_4("Ion Icons 4", Stream.concat(
-            Stream.concat(
-                    Arrays.stream(Ionicons4IOS.values()).map(ios -> (Ikon) ios),
-                    Arrays.stream(Ionicons4Logo.values()).map(logo -> (Ikon) logo)
-            ),
-            Arrays.stream(Ionicons4Material.values()).map(material -> (Ikon) material)
+      Stream.concat(
+        Arrays.stream(Ionicons4IOS.values()).map(ios -> (Ikon) ios),
+        Arrays.stream(Ionicons4Logo.values()).map(logo -> (Ikon) logo)
+      ),
+      Arrays.stream(Ionicons4Material.values()).map(material -> (Ikon) material)
     ).toArray(Ikon[]::new)),
     LINE_AWESOME("Line Awesome", Stream.concat(
-            Stream.concat(
-                    Arrays.stream(LineAwesomeBrands.values()).map(brands -> (Ikon) brands),
-                    Arrays.stream(LineAwesomeRegular.values()).map(regular -> (Ikon) regular)
-            ),
-            Arrays.stream(LineAwesomeSolid.values()).map(solid -> (Ikon) solid)
+      Stream.concat(
+        Arrays.stream(LineAwesomeBrands.values()).map(brands -> (Ikon) brands),
+        Arrays.stream(LineAwesomeRegular.values()).map(regular -> (Ikon) regular)
+      ),
+      Arrays.stream(LineAwesomeSolid.values()).map(solid -> (Ikon) solid)
     ).toArray(Ikon[]::new)),
     WEATHER_ICONS("Weather Icons", WeatherIcons.values()),
     DEVI_ICONS("Devi Icons", Devicons.values()),
     MATERIAL_2("Material 2", Stream.concat(
-            Stream.concat(
-                    Stream.concat(
-                            Arrays.stream(Material2AL.values()).map(al -> (Ikon) al),
-                            Arrays.stream(Material2MZ.values()).map(mz -> (Ikon) mz)
-                    ),
-                    Stream.concat(
-                            Arrays.stream(Material2OutlinedAL.values()).map(outlinedAL -> (Ikon) outlinedAL),
-                            Arrays.stream(Material2OutlinedMZ.values()).map(outlinedMZ -> (Ikon) outlinedMZ)
-                    )
-            ),
-            Stream.concat(
-                    Stream.concat(
-                            Arrays.stream(Material2RoundAL.values()).map(roundAL -> (Ikon) roundAL),
-                            Arrays.stream(Material2RoundMZ.values()).map(roundMZ -> (Ikon) roundMZ)
-                    ),
-                    Stream.concat(
-                            Arrays.stream(Material2SharpAL.values()).map(sharpAL -> (Ikon) sharpAL),
-                            Arrays.stream(Material2SharpMZ.values()).map(sharpMZ -> (Ikon) sharpMZ)
-                    )
-            )
+      Stream.concat(
+        Stream.concat(
+          Arrays.stream(Material2AL.values()).map(al -> (Ikon) al),
+          Arrays.stream(Material2MZ.values()).map(mz -> (Ikon) mz)
+        ),
+        Stream.concat(
+          Arrays.stream(Material2OutlinedAL.values()).map(outlinedAL -> (Ikon) outlinedAL),
+          Arrays.stream(Material2OutlinedMZ.values()).map(outlinedMZ -> (Ikon) outlinedMZ)
+        )
+      ),
+      Stream.concat(
+        Stream.concat(
+          Arrays.stream(Material2RoundAL.values()).map(roundAL -> (Ikon) roundAL),
+          Arrays.stream(Material2RoundMZ.values()).map(roundMZ -> (Ikon) roundMZ)
+        ),
+        Stream.concat(
+          Arrays.stream(Material2SharpAL.values()).map(sharpAL -> (Ikon) sharpAL),
+          Arrays.stream(Material2SharpMZ.values()).map(sharpMZ -> (Ikon) sharpMZ)
+        )
+      )
     ).toArray(Ikon[]::new)),
     DASH_ICONS("Dash Icons", Dashicons.values()),
     ELUSIVE("Elusive", Elusive.values()),
@@ -141,11 +141,11 @@ public enum Pack {
     CARBON_ICONS("Carbon Icons", CarbonIcons.values()),
     PRESTA_SHOP_ICONS("Presta Shop Icons", PrestaShopIcons.values()),
     UNICONS("Unicons", Stream.concat(
-            Stream.concat(
-                    Arrays.stream(UniconsLine.values()).map(line -> (Ikon) line),
-                    Arrays.stream(UniconsMonochrome.values()).map(monochrome -> (Ikon) monochrome)
-            ),
-            Arrays.stream(UniconsSolid.values()).map(solid -> (Ikon) solid)
+      Stream.concat(
+        Arrays.stream(UniconsLine.values()).map(line -> (Ikon) line),
+        Arrays.stream(UniconsMonochrome.values()).map(monochrome -> (Ikon) monochrome)
+      ),
+      Arrays.stream(UniconsSolid.values()).map(solid -> (Ikon) solid)
     ).toArray(Ikon[]::new)),
     LINECONS("Linecons", Linecons.values()),
     CAPTAIN_ICON("Captain Icon", Captainicon.values()),
@@ -156,15 +156,13 @@ public enum Pack {
     CODICONS("Codicons", Codicons.values()),
     OCI_ICONS("Oci Icons", Ociicons.values()),
     REMIX_ICON("Remix Icon", Stream.concat(
-            Arrays.stream(RemixiconAL.values()).map(al -> (Ikon) al),
-            Arrays.stream(RemixiconMZ.values()).map(mz -> (Ikon) mz)
-
+      Arrays.stream(RemixiconAL.values()).map(al -> (Ikon) al),
+      Arrays.stream(RemixiconMZ.values()).map(mz -> (Ikon) mz)
     ).toArray(Ikon[]::new)),
     ION_ICONS("Ion Icons", Ionicons.values()),
     ANT_DESIGN_ICONS("Ant Design Icons", Stream.concat(
-            Arrays.stream(AntDesignIconsFilled.values()).map(filled -> (Ikon) filled),
-            Arrays.stream(AntDesignIconsOutlined.values()).map(outlined -> (Ikon) outlined)
-
+      Arrays.stream(AntDesignIconsFilled.values()).map(filled -> (Ikon) filled),
+      Arrays.stream(AntDesignIconsOutlined.values()).map(outlined -> (Ikon) outlined)
     ).toArray(Ikon[]::new)),
     SUBWAY("Subway", Subway.values()),
     SIMPLE_LINE_ICONS("Simple Line Icons", SimpleLineIcons.values()),
@@ -172,9 +170,8 @@ public enum Pack {
     MAKI("Maki", Maki.values()),
     MAKI_2("Maki 2", Maki2.values()),
     WHHG("Whhg", Stream.concat(
-            Arrays.stream(WhhgAL.values()).map(al -> (Ikon) al),
-            Arrays.stream(WhhgMZ.values()).map(mz -> (Ikon) mz)
-
+      Arrays.stream(WhhgAL.values()).map(al -> (Ikon) al),
+      Arrays.stream(WhhgMZ.values()).map(mz -> (Ikon) mz)
     ).toArray(Ikon[]::new)),
     SIMPLE_ICONS("Simple Icons", SimpleIcons.values()),
     FOUNDATION("Foundation", Foundation.values()),
@@ -183,42 +180,39 @@ public enum Pack {
     BPMN("Bpmn", Bpmn.values()),
     TYPICONS("Typicons", Typicons.values()),
     HAWCONS("Hawcons", Stream.concat(
-            Arrays.stream(HawconsFilled.values()).map(filled -> (Ikon) filled),
-            Arrays.stream(HawconsStroke.values()).map(stroke -> (Ikon) stroke)
-
+      Arrays.stream(HawconsFilled.values()).map(filled -> (Ikon) filled),
+      Arrays.stream(HawconsStroke.values()).map(stroke -> (Ikon) stroke)
     ).toArray(Ikon[]::new)),
     MAP_ICONS("Map Icons", Mapicons.values()),
     METRIZE_ICONS("Metrize Icons", MetrizeIcons.values()),
     CORE_UI("Core UI", Stream.concat(
-            Arrays.stream(CoreUiBrands.values()).map(brands -> (Ikon) brands),
-            Arrays.stream(CoreUiFree.values()).map(free -> (Ikon) free)
-
+      Arrays.stream(CoreUiBrands.values()).map(brands -> (Ikon) brands),
+      Arrays.stream(CoreUiFree.values()).map(free -> (Ikon) free)
     ).toArray(Ikon[]::new)),
     RUNESTRO_ICONS("Runestro Icons", Runestroicons.values()),
     PAYMENT_FONT("Payment Font", PaymentFont.values()),
     FLUENT_UI("Fluent UI", Stream.concat(
-            Stream.concat(
-                    Arrays.stream(FluentUiFilledAL.values()).map(filledAL -> (Ikon) filledAL),
-                    Arrays.stream(FluentUiFilledMZ.values()).map(filledMZ -> (Ikon) filledMZ)
-            ),
-            Stream.concat(
-                    Arrays.stream(FluentUiRegularAL.values()).map(regularAL -> (Ikon) regularAL),
-                    Arrays.stream(FluentUiRegularMZ.values()).map(regularMZ -> (Ikon) regularMZ)
-            )
+      Stream.concat(
+        Arrays.stream(FluentUiFilledAL.values()).map(filledAL -> (Ikon) filledAL),
+        Arrays.stream(FluentUiFilledMZ.values()).map(filledMZ -> (Ikon) filledMZ)
+      ),
+      Stream.concat(
+        Arrays.stream(FluentUiRegularAL.values()).map(regularAL -> (Ikon) regularAL),
+        Arrays.stream(FluentUiRegularMZ.values()).map(regularMZ -> (Ikon) regularMZ)
+      )
     ).toArray(Ikon[]::new)),
     WIN_10("Win 10", Win10.values()),
     FONTELICO("Fontelico", Fontelico.values()),
     BOX_ICONS("Box Icons", Stream.concat(
-            Stream.concat(
-                    Arrays.stream(BoxiconsLogos.values()).map(logos -> (Ikon) logos),
-                    Arrays.stream(BoxiconsRegular.values()).map(regular -> (Ikon) regular)
-            ),
-            Arrays.stream(BoxiconsSolid.values()).map(solid -> (Ikon) solid)
+      Stream.concat(
+        Arrays.stream(BoxiconsLogos.values()).map(logos -> (Ikon) logos),
+        Arrays.stream(BoxiconsRegular.values()).map(regular -> (Ikon) regular)
+      ),
+      Arrays.stream(BoxiconsSolid.values()).map(solid -> (Ikon) solid)
     ).toArray(Ikon[]::new)),
     ENTYPO("Entypo", Entypo.values()),
     ICOMOON("Icomoon", Icomoon.values()),
     MED_ICONS("Med Icons", Medicons.values());
-
     private final String description;
     private final Ikon[] ikons;
 
@@ -239,4 +233,4 @@ public enum Pack {
     private static Ikon[] copy(Ikon[] ikons) {
         return Arrays.copyOf(ikons, ikons.length);
     }
-    }
+}

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Update.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Update.java
@@ -1,0 +1,131 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Hiram K
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.idelstak.ikonx.mvu;
+
+import com.github.idelstak.ikonx.*;
+import com.github.idelstak.ikonx.mvu.action.*;
+import com.github.idelstak.ikonx.mvu.state.*;
+import java.util.*;
+
+public final class Update {
+
+    private final Map<Pack, List<PackIkon>> iconCache;
+    private final List<Pack> orderedPacks;
+
+    public Update() {
+        iconCache = new EnumMap<>(Pack.class);
+        for (var pack : Pack.values()) {
+            iconCache.put(
+              pack,
+              Arrays.stream(pack.getIkons())
+                .map(ikon -> new PackIkon(pack, ikon))
+                .toList()
+            );
+        }
+
+        orderedPacks = Arrays.stream(Pack.values())
+          .sorted(Comparator.comparing(Enum::name))
+          .toList();
+    }
+
+    public ViewState apply(ViewState state, Action action) {
+        return switch (action) {
+            case Action.SearchChanged a ->
+                search(state, a);
+            case Action.PackToggled a ->
+                toggle(state, a);
+            case Action.SelectAllToggled a ->
+                toggleAll(state, a);
+            case Action.IconCopied a ->
+                copy(state, a);
+        };
+    }
+
+    private ViewState search(ViewState state, Action.SearchChanged action) {
+        var icons = filterIcons(state.selectedPacks(), action.query());
+        return state
+          .search(action.query())
+          .display(icons)
+          .signal(new ActivityState.Idle())
+          .message(String.format("%d icons found", icons.size()));
+    }
+
+    private ViewState toggle(ViewState state, Action.PackToggled action) {
+        var packs = new HashSet<>(state.selectedPacks());
+        if (action.isSelected()) {
+            packs.add(action.pack());
+        } else {
+            packs.remove(action.pack());
+        }
+
+        var icons = filterIcons(packs, state.searchText());
+        return state
+          .select(packs)
+          .display(icons)
+          .signal(new ActivityState.Idle())
+          .message(String.format("%d icons found", icons.size()));
+    }
+
+    private ViewState toggleAll(ViewState state, Action.SelectAllToggled action) {
+        Set<Pack> packs;
+
+        if (action.isSelected()) {
+            packs = Set.copyOf(orderedPacks);
+        } else {
+            packs = Set.of(orderedPacks.getFirst());
+        }
+
+        var icons = filterIcons(packs, state.searchText());
+        return state
+          .select(packs)
+          .display(icons)
+          .signal(new ActivityState.Idle())
+          .message(String.format("%d icons found", icons.size()));
+    }
+
+    private ViewState copy(ViewState state, Action.IconCopied action) {
+        return state
+          .signal(new ActivityState.Success())
+          .message("Copied '" + action.iconCode() + "' to clipboard");
+    }
+
+    private List<PackIkon> filterIcons(Set<Pack> selectedPacks, String searchText) {
+        if (selectedPacks.isEmpty()) {
+            return List.of();
+        }
+
+        var icons = selectedPacks.stream()
+          .flatMap(pack -> iconCache.get(pack).stream())
+          .toList();
+
+        if (searchText == null || searchText.isBlank() || searchText.length() < 2) {
+            return icons;
+        }
+
+        var lower = searchText.toLowerCase(Locale.ROOT);
+        return icons.stream()
+          .filter(ikon -> ikon.ikon().getDescription().toLowerCase(Locale.ROOT).contains(lower))
+          .toList();
+    }
+}

--- a/src/main/java/com/github/idelstak/ikonx/mvu/state/ViewState.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/state/ViewState.java
@@ -39,13 +39,42 @@ public record ViewState(
         displayedIcons = List.copyOf(displayedIcons);
     }
 
+    public ViewState search(String text) {
+        return new ViewState(text, selectedPacks, displayedIcons, status, statusMessage);
+    }
+
+    public ViewState select(Set<Pack> packs) {
+        return new ViewState(searchText, packs, displayedIcons, status, statusMessage);
+    }
+
+    public ViewState display(List<PackIkon> icons) {
+        return new ViewState(searchText, selectedPacks, icons, status, statusMessage);
+    }
+
+    public ViewState signal(ActivityState state) {
+        return new ViewState(searchText, selectedPacks, displayedIcons, state, statusMessage);
+    }
+
+    public ViewState message(String text) {
+        return new ViewState(searchText, selectedPacks, displayedIcons, status, text);
+    }
+
     public static ViewState initial() {
+        var first = Arrays.stream(Pack.values())
+          .sorted(Comparator.comparing(Enum::name))
+          .findFirst()
+          .orElseThrow();
+
+        var icons = Arrays.stream(first.getIkons())
+          .map(ikon -> new PackIkon(first, ikon))
+          .toList();
+
         return new ViewState(
-          "", // Search text is empty
-          Set.of(), // No packs are selected initially
-          List.of(), // No icons are displayed
-          new Idle(), // Initial status
-          "0 icons" // Status message
+          "",
+          Set.of(first),
+          icons,
+          new Idle(),
+          String.format("%d icons found", icons.size())
         );
     }
 }

--- a/src/test/java/com/github/idelstak/ikonx/mvu/UpdateTest.java
+++ b/src/test/java/com/github/idelstak/ikonx/mvu/UpdateTest.java
@@ -1,0 +1,155 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Hiram K
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.idelstak.ikonx.mvu;
+
+import com.github.idelstak.ikonx.*;
+import com.github.idelstak.ikonx.mvu.action.*;
+import com.github.idelstak.ikonx.mvu.state.*;
+import java.util.*;
+import org.junit.jupiter.api.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+final class UpdateTest {
+
+    @Test
+    void searchUpdatesText() {
+        var update = new Update();
+        var state = ViewState.initial();
+        var next = update.apply(state, new Action.SearchChanged("αβ"));
+
+        assertThat(next.searchText(), is("αβ"));
+    }
+
+    @Test
+    void searchResetsStatus() {
+        var update = new Update();
+        var state = ViewState.initial()
+          .signal(new ActivityState.Success());
+
+        var next = update.apply(state, new Action.SearchChanged("αβ"));
+
+        assertThat(next.status(), instanceOf(ActivityState.Idle.class));
+    }
+
+    @Test
+    void toggleAddsPack() {
+        var update = new Update();
+        var state = ViewState.initial();
+        var pack = Pack.values()[0];
+
+        var next = update.apply(
+          state,
+          new Action.PackToggled(pack, true)
+        );
+
+        assertThat(next.selectedPacks(), hasItem(pack));
+    }
+
+    @Test
+    void toggleRemovesPack() {
+        var update = new Update();
+        var pack = Pack.values()[0];
+
+        var state = ViewState.initial().select(Set.of(pack));
+
+        var next = update.apply(
+          state,
+          new Action.PackToggled(pack, false)
+        );
+
+        assertThat(next.selectedPacks(), not(hasItem(pack)));
+    }
+
+    @Test
+    void selectAllSelectsEveryPack() {
+        var update = new Update();
+        var state = ViewState.initial();
+
+        var next = update.apply(
+          state,
+          new Action.SelectAllToggled(true)
+        );
+
+        assertThat(next.selectedPacks(), hasSize(Pack.values().length));
+    }
+
+    @Test
+    void selectAllLeavesFirstPackSelected() {
+        var update = new Update();
+        var state = ViewState.initial().select(Set.of(Pack.values()));
+
+        var next = update.apply(
+          state,
+          new Action.SelectAllToggled(false)
+        );
+
+        var ordered = Arrays.stream(Pack.values())
+          .sorted(Comparator.comparing(Enum::name))
+          .toList();
+        assertThat(next.selectedPacks(), is(Set.of(ordered.getFirst())));
+    }
+
+    @Test
+    void copySignalsSuccess() {
+        var update = new Update();
+        var state = ViewState.initial();
+
+        var next = update.apply(
+          state,
+          new Action.IconCopied("λ")
+        );
+
+        assertThat(next.status(), instanceOf(ActivityState.Success.class));
+    }
+
+    @Test
+    void copyUpdatesMessage() {
+        var update = new Update();
+        var state = ViewState.initial();
+
+        var next = update.apply(
+          state,
+          new Action.IconCopied("λ")
+        );
+
+        assertThat(
+          next.statusMessage(),
+          is("Copied 'λ' to clipboard")
+        );
+    }
+
+    @Test
+    void emptySelectionDisplaysNoIcons() {
+        var update = new Update();
+        var state = ViewState.initial();
+
+        var next = update.apply(
+          state,
+          new Action.SearchChanged("αβ")
+        );
+
+        assertThat(next.displayedIcons(), is(empty()));
+    }
+}


### PR DESCRIPTION
Introduce a fluent API to `ViewState` for clearer and more declarative state updates.

- Added `search()`, `select()`, `display()`, `signal()`, and `message()` methods for immutable state transitions.
- The `initial()` state now loads the first available icon pack by default, providing a more useful starting point.
- Also, added NetBeans project files to `.gitignore` and refactored `Pack.java` for better code style.