### PR TITLE
Refactor MVU components and fix UI threading

### DIFF
--- a/src/main/java/com/github/idelstak/ikonx/Ikonx.java
+++ b/src/main/java/com/github/idelstak/ikonx/Ikonx.java
@@ -30,22 +30,20 @@ import javafx.fxml.*;
 import javafx.scene.*;
 import javafx.stage.*;
 
-/**
- * @author Hiram K. <a href="https://github.com/IdelsTak">Link</a>
- * @Contributor Kapil Kumar <a href="https://github.com/kapilkumar9976">Link</a>
- */
-public final class Ikonx extends Application {
+public class Ikonx extends Application {
 
     private IconView controller;
+
 
     @Override
     public void start(Stage primaryStage) throws Exception {
         var loader = new FXMLLoader(getClass().getResource("/fxml/icon-view.fxml"));
+        loader.setControllerFactory(param -> {
+            controller = new IconView(new StateFlow());
+            return controller;
+        });
         var root = loader.<Parent>load();
-        controller = loader.<IconView>getController();
-        controller.initFlow(new StateFlow());
         var scene = new Scene(root);
-        //Application.setUserAgentStylesheet(new PrimerLight().getUserAgentStylesheet()); // updated and upgraded by https://github.com/kapilkumar9976
 
         primaryStage.setScene(scene);
         primaryStage.initStyle(StageStyle.UNIFIED);

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Flow.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Flow.java
@@ -25,38 +25,11 @@ package com.github.idelstak.ikonx.mvu;
 
 import com.github.idelstak.ikonx.mvu.action.*;
 import com.github.idelstak.ikonx.mvu.state.*;
-import io.reactivex.rxjava3.core.Observable;
-import io.reactivex.rxjava3.subjects.*;
-import java.util.*;
+import io.reactivex.rxjava3.core.*;
 
-public final class StateFlow implements Flow {
+public interface Flow {
 
-    private final Subject<Action> actions;
-    private final Deque<Action> actionHistory;
-    private final Update update;
-    private final Observable<ViewState> states;
+    void accept(Action action);
 
-    public StateFlow() {
-        actions = PublishSubject.<Action>create().toSerialized();
-        actionHistory = new ArrayDeque<>();
-        update = new Update();
-        states = actions
-          .doOnNext(actionHistory::add)
-          .scan(ViewState.initial(), update::apply)
-          .doOnNext(state -> {
-          })
-          .distinctUntilChanged()
-          .replay(1)
-          .autoConnect();
-    }
-
-    @Override
-    public void accept(Action action) {
-        actions.onNext(action);
-    }
-
-    @Override
-    public Observable<ViewState> observe() {
-        return states;
-    }
+    Observable<ViewState> observe();
 }

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Update.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Update.java
@@ -37,16 +37,16 @@ public final class Update {
         iconCache = new EnumMap<>(Pack.class);
         for (var pack : Pack.values()) {
             iconCache.put(
-              pack,
-              Arrays.stream(pack.getIkons())
-                .map(ikon -> new PackIkon(pack, ikon))
-                .toList()
+                    pack,
+                    Arrays.stream(pack.getIkons())
+                            .map(ikon -> new PackIkon(pack, ikon))
+                            .toList()
             );
         }
 
         orderedPacks = Arrays.stream(Pack.values())
-          .sorted(Comparator.comparing(Enum::name))
-          .toList();
+                .sorted(Comparator.comparing(Enum::name))
+                .toList();
     }
 
     public ViewState apply(ViewState state, Action action) {
@@ -65,16 +65,15 @@ public final class Update {
     private ViewState search(ViewState state, Action.SearchChanged action) {
         var icons = filterIcons(state.selectedPacks(), action.query());
         return state
-          .search(action.query())
-          .display(icons)
-          .signal(new ActivityState.Idle())
-          .message(String.format("%d icons found", icons.size()));
+                .search(action.query())
+                .display(icons)
+                .signal(new ActivityState.Idle())
+                .message(String.format("%d icons found", icons.size()));
     }
 
     private ViewState toggle(ViewState state, Action.PackToggled action) {
         var packs = new HashSet<>(state.selectedPacks());
         var pack = action.pack();
-        
         if (action.isSelected()) {
             packs.add(pack);
         } else {
@@ -83,10 +82,10 @@ public final class Update {
 
         var icons = filterIcons(packs, state.searchText());
         return state
-          .select(packs)
-          .display(icons)
-          .signal(new ActivityState.Idle())
-          .message(String.format("%d icons found", icons.size()));
+                .select(packs)
+                .display(icons)
+                .signal(new ActivityState.Idle())
+                .message(String.format("%d icons found", icons.size()));
     }
 
     private ViewState toggleAll(ViewState state, Action.SelectAllToggled action) {
@@ -100,16 +99,16 @@ public final class Update {
 
         var icons = filterIcons(packs, state.searchText());
         return state
-          .select(packs)
-          .display(icons)
-          .signal(new ActivityState.Idle())
-          .message(String.format("%d icons found", icons.size()));
+                .select(packs)
+                .display(icons)
+                .signal(new ActivityState.Idle())
+                .message(String.format("%d icons found", icons.size()));
     }
 
     private ViewState copy(ViewState state, Action.IconCopied action) {
         return state
-          .signal(new ActivityState.Success())
-          .message("Copied '" + action.iconCode() + "' to clipboard");
+                .signal(new ActivityState.Success())
+                .message("Copied '" + action.iconCode() + "' to clipboard");
     }
 
     private List<PackIkon> filterIcons(Set<Pack> selectedPacks, String searchText) {
@@ -118,8 +117,8 @@ public final class Update {
         }
 
         var icons = selectedPacks.stream()
-          .flatMap(pack -> iconCache.get(pack).stream())
-          .toList();
+                .flatMap(pack -> iconCache.get(pack).stream())
+                .toList();
 
         if (searchText == null || searchText.isBlank() || searchText.length() < 2) {
             return icons;
@@ -127,7 +126,7 @@ public final class Update {
 
         var lower = searchText.toLowerCase(Locale.ROOT);
         return icons.stream()
-          .filter(ikon -> ikon.ikon().getDescription().toLowerCase(Locale.ROOT).contains(lower))
-          .toList();
+                .filter(ikon -> ikon.ikon().getDescription().toLowerCase(Locale.ROOT).contains(lower))
+                .toList();
     }
 }

--- a/src/main/resources/fxml/icon-view.fxml
+++ b/src/main/resources/fxml/icon-view.fxml
@@ -7,7 +7,7 @@
 <?import org.controlsfx.control.*?>
 <?import org.kordamp.ikonli.javafx.*?>
 
-<VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="900.0" stylesheets="@../styles/theme.css" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.idelstak.ikonx.view.IconView">
+<VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="900.0" stylesheets="@../styles/theme.css" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.idelstak.ikonx.view.IconView">
     <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" VBox.vgrow="ALWAYS">
         <padding>
             <Insets bottom="6.0" left="6.0" right="6.0" top="6.0" />
@@ -45,9 +45,9 @@
                 <TableColumn />
                 <TableColumn />
             </columns>
-            <columnResizePolicy>
-                <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
-            </columnResizePolicy>
+         <columnResizePolicy>
+            <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+         </columnResizePolicy>
         </TableView>
     </VBox>
    <StatusBar fx:id="statusBar" text="" />


### PR DESCRIPTION
- Decouple the IconView from the concrete StateFlow by introducing a Flow interface and using constructor injection. This improves modularity and testability.
 - Ensure UI updates are performed on the JavaFX Application Thread by using Platform.runLater in the render method, preventing potential threading exceptions.