### PR TITLE
Refactor MVU to cleanly separate side effects

### DIFF
--- a/src/main/java/com/github/idelstak/ikonx/Ikonx.java
+++ b/src/main/java/com/github/idelstak/ikonx/Ikonx.java
@@ -32,19 +32,15 @@ import javafx.stage.*;
 
 public class Ikonx extends Application {
 
-    private IconView controller;
-
     @Override
     public void start(Stage primaryStage) throws Exception {
         var loader = new FXMLLoader(getClass().getResource("/fxml/icon-view.fxml"));
-        loader.setControllerFactory(param -> {
-            controller = new IconView(new StateFlow());
-            return controller;
-        });
+        loader.setControllerFactory(_ -> new IconView(new StateFlow()));
         var root = loader.<Parent>load();
         var scene = new Scene(root);
 
         primaryStage.setOnCloseRequest(_ -> {
+            var controller = loader.<IconView>getController();
             if (controller != null) {
                 controller.dispose();
             }

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Effect.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Effect.java
@@ -21,20 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.idelstak.ikonx.icons;
+package com.github.idelstak.ikonx.mvu;
 
-import org.kordamp.ikonli.*;
+public sealed interface Effect permits Effect.CopyToClipboard {
 
-public record PackIkon(Pack pack, Ikon ikon) {
+    record CopyToClipboard(String text) implements Effect {
 
-    @Override
-    public String toString() {
-        var sb = new StringBuilder();
-        sb.append('{');
-        sb.append(pack);
-        sb.append(", ").append(ikon.getDescription());
-        sb.append('}');
-        return sb.toString();
     }
-    
 }

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Flow.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Flow.java
@@ -24,12 +24,11 @@
 package com.github.idelstak.ikonx.mvu;
 
 import com.github.idelstak.ikonx.mvu.action.*;
-import com.github.idelstak.ikonx.mvu.state.*;
 import io.reactivex.rxjava3.core.*;
 
 public interface Flow {
 
     void accept(Action action);
 
-    Observable<ViewState> observe();
+    Observable<UpdateResult> observe();
 }

--- a/src/main/java/com/github/idelstak/ikonx/mvu/StateFlow.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/StateFlow.java
@@ -24,7 +24,6 @@
 package com.github.idelstak.ikonx.mvu;
 
 import com.github.idelstak.ikonx.mvu.action.*;
-import com.github.idelstak.ikonx.mvu.state.*;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.subjects.*;
 import java.util.*;
@@ -34,7 +33,7 @@ public final class StateFlow implements Flow {
     private final Subject<Action> actions;
     private final Deque<Action> actionHistory;
     private final Update update;
-    private final Observable<ViewState> states;
+    private final Observable<UpdateResult> states;
 
     public StateFlow() {
         actions = PublishSubject.<Action>create().toSerialized();
@@ -42,9 +41,7 @@ public final class StateFlow implements Flow {
         update = new Update();
         states = actions
           .doOnNext(actionHistory::add)
-          .scan(ViewState.initial(), update::apply)
-          .doOnNext(state -> {
-          })
+          .scan(UpdateResult.initial(), (result, action) -> update.apply(result.state(), action))
           .distinctUntilChanged()
           .replay(1)
           .autoConnect();
@@ -56,7 +53,7 @@ public final class StateFlow implements Flow {
     }
 
     @Override
-    public Observable<ViewState> observe() {
+    public Observable<UpdateResult> observe() {
         return states;
     }
 }

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Update.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Update.java
@@ -37,38 +37,40 @@ public final class Update {
         iconCache = new EnumMap<>(Pack.class);
         for (var pack : Pack.values()) {
             iconCache.put(
-                    pack,
-                    Arrays.stream(pack.getIkons())
-                            .map(ikon -> new PackIkon(pack, ikon))
-                            .toList()
+              pack,
+              Arrays.stream(pack.getIkons())
+                .map(ikon -> new PackIkon(pack, ikon))
+                .toList()
             );
         }
 
         orderedPacks = Arrays.stream(Pack.values())
-                .sorted(Comparator.comparing(Enum::name))
-                .toList();
+          .sorted(Comparator.comparing(Enum::name))
+          .toList();
     }
 
-    public ViewState apply(ViewState state, Action action) {
+    public UpdateResult apply(ViewState state, Action action) {
         return switch (action) {
             case Action.SearchChanged a ->
-                search(state, a);
+                new UpdateResult(search(state, a), Optional.empty());
             case Action.PackToggled a ->
-                toggle(state, a);
+                new UpdateResult(toggle(state, a), Optional.empty());
             case Action.SelectAllToggled a ->
-                toggleAll(state, a);
+                new UpdateResult(toggleAll(state, a), Optional.empty());
+//            case Action.IconCopied a ->
+//                new UpdateResult(copy(state, a), Optional.empty());
             case Action.IconCopied a ->
-                copy(state, a);
+                new UpdateResult(copy(state, a), Optional.of(new Effect.CopyToClipboard(a.iconCode())));
         };
     }
 
     private ViewState search(ViewState state, Action.SearchChanged action) {
         var icons = filterIcons(state.selectedPacks(), action.query());
         return state
-                .search(action.query())
-                .display(icons)
-                .signal(new ActivityState.Idle())
-                .message(String.format("%d icons found", icons.size()));
+          .search(action.query())
+          .display(icons)
+          .signal(new ActivityState.Idle())
+          .message(String.format("%d icons found", icons.size()));
     }
 
     private ViewState toggle(ViewState state, Action.PackToggled action) {
@@ -82,10 +84,10 @@ public final class Update {
 
         var icons = filterIcons(packs, state.searchText());
         return state
-                .select(packs)
-                .display(icons)
-                .signal(new ActivityState.Idle())
-                .message(String.format("%d icons found", icons.size()));
+          .select(packs)
+          .display(icons)
+          .signal(new ActivityState.Idle())
+          .message(String.format("%d icons found", icons.size()));
     }
 
     private ViewState toggleAll(ViewState state, Action.SelectAllToggled action) {
@@ -99,16 +101,16 @@ public final class Update {
 
         var icons = filterIcons(packs, state.searchText());
         return state
-                .select(packs)
-                .display(icons)
-                .signal(new ActivityState.Idle())
-                .message(String.format("%d icons found", icons.size()));
+          .select(packs)
+          .display(icons)
+          .signal(new ActivityState.Idle())
+          .message(String.format("%d icons found", icons.size()));
     }
 
     private ViewState copy(ViewState state, Action.IconCopied action) {
         return state
-                .signal(new ActivityState.Success())
-                .message("Copied '" + action.iconCode() + "' to clipboard");
+          .signal(new ActivityState.Success())
+          .message("Copied '" + action.iconCode() + "' to clipboard");
     }
 
     private List<PackIkon> filterIcons(Set<Pack> selectedPacks, String searchText) {
@@ -117,8 +119,8 @@ public final class Update {
         }
 
         var icons = selectedPacks.stream()
-                .flatMap(pack -> iconCache.get(pack).stream())
-                .toList();
+          .flatMap(pack -> iconCache.get(pack).stream())
+          .toList();
 
         if (searchText == null || searchText.isBlank() || searchText.length() < 2) {
             return icons;
@@ -126,7 +128,7 @@ public final class Update {
 
         var lower = searchText.toLowerCase(Locale.ROOT);
         return icons.stream()
-                .filter(ikon -> ikon.ikon().getDescription().toLowerCase(Locale.ROOT).contains(lower))
-                .toList();
+          .filter(ikon -> ikon.ikon().getDescription().toLowerCase(Locale.ROOT).contains(lower))
+          .toList();
     }
 }

--- a/src/main/java/com/github/idelstak/ikonx/mvu/UpdateResult.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/UpdateResult.java
@@ -21,20 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.idelstak.ikonx.icons;
+package com.github.idelstak.ikonx.mvu;
 
-import org.kordamp.ikonli.*;
+import com.github.idelstak.ikonx.mvu.state.*;
+import java.util.*;
 
-public record PackIkon(Pack pack, Ikon ikon) {
+public record UpdateResult(ViewState state, Optional<Effect> effect) {
 
-    @Override
-    public String toString() {
-        var sb = new StringBuilder();
-        sb.append('{');
-        sb.append(pack);
-        sb.append(", ").append(ikon.getDescription());
-        sb.append('}');
-        return sb.toString();
+    public static UpdateResult initial() {
+        return new UpdateResult(ViewState.initial(), Optional.empty());
     }
-    
 }

--- a/src/main/java/com/github/idelstak/ikonx/view/FontIconCell.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/FontIconCell.java
@@ -23,36 +23,35 @@
  */
 package com.github.idelstak.ikonx.view;
 
-import com.github.idelstak.ikonx.icons.*;
-import com.github.idelstak.ikonx.mvu.action.*;
-import java.util.*;
-import java.util.function.*;
-import javafx.scene.control.*;
-import org.kordamp.ikonli.javafx.*;
+import com.github.idelstak.ikonx.icons.PackIkon;
+import com.github.idelstak.ikonx.mvu.action.Action;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Label;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.TableCell;
+import org.kordamp.ikonli.javafx.FontIcon;
+import java.util.List;
+import java.util.function.Consumer;
 
 final class FontIconCell extends TableCell<List<PackIkon>, PackIkon> {
 
-    private final Label root = new Label();
-    private final FontIcon fontIcon = new FontIcon();
     private final Consumer<Action> dispatch;
+    private final Label root;
+    private final FontIcon fontIcon;
 
     FontIconCell(Consumer<Action> dispatch) {
         super();
         this.dispatch = dispatch;
 
+        root = new Label();
+        fontIcon = new FontIcon();
+
         root.setContentDisplay(ContentDisplay.TOP);
         root.setGraphic(fontIcon);
         root.setGraphicTextGap(10);
         root.getStyleClass().addAll("icon-label", "text-small");
-
         fontIcon.iconColorProperty().bind(root.textFillProperty());
-
-        root.setOnMouseClicked(event -> {
-            var currentItem = getItem();
-            if (event.getClickCount() == 1 && currentItem != null) {
-                dispatch.accept(new Action.IconCopied(currentItem.ikon().getDescription()));
-            }
-        });
     }
 
     @Override
@@ -62,28 +61,33 @@ final class FontIconCell extends TableCell<List<PackIkon>, PackIkon> {
         if (packIkon == null || empty) {
             setGraphic(null);
         } else {
+            root.setText(packIkon.ikon().getDescription());
+            fontIcon.setIconCode(packIkon.ikon());
+
+            root.setOnMouseClicked(event -> {
+                if (event.getClickCount() == 1) {
+                    dispatch.accept(new Action.IconCopied(packIkon.ikon().getDescription()));
+                }
+            });
+
             var contextMenu = new ContextMenu();
             var copyItem = new MenuItem("Copy icon code");
             copyItem.setOnAction(_ ->
-            {
-                dispatch.accept(new Action.IconCopied(packIkon.ikon().getDescription()));
-            });
+              dispatch.accept(new Action.IconCopied(packIkon.ikon().getDescription())));
             contextMenu.getItems().add(copyItem);
-
             root.setContextMenu(contextMenu);
-            root.setText(packIkon.ikon().getDescription());
-            fontIcon.setIconCode(packIkon.ikon());
+
             setGraphic(root);
         }
-
     }
-//    private void copyIconCodeToClipboard() {
-//        String iconCode = fontIcon.getIconCode().getDescription();
-//
-//        if (iconCode != null && !iconCode.isEmpty()) {
-//            ClipboardContent content = new ClipboardContent();
-//            content.putString(iconCode);
-//            Clipboard.getSystemClipboard().setContent(content);
-//        }
-//    }
+
+    @Override
+    public String toString() {
+        var sb = new StringBuilder();
+        sb.append('{');
+        sb.append("root=").append(root.getText());
+        sb.append(", fontIcon=").append(fontIcon.getIconLiteral());
+        sb.append('}');
+        return fontIcon.getIconLiteral();
+    }
 }

--- a/src/main/java/com/github/idelstak/ikonx/view/IconClipboard.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/IconClipboard.java
@@ -21,20 +21,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.idelstak.ikonx.icons;
+package com.github.idelstak.ikonx.view;
 
-import org.kordamp.ikonli.*;
+import javafx.scene.input.*;
 
-public record PackIkon(Pack pack, Ikon ikon) {
+public final class IconClipboard implements LocalClipboard {
 
     @Override
-    public String toString() {
-        var sb = new StringBuilder();
-        sb.append('{');
-        sb.append(pack);
-        sb.append(", ").append(ikon.getDescription());
-        sb.append('}');
-        return sb.toString();
+    public void copy(String text) {
+        var content = new ClipboardContent();
+        content.putString(text);
+        System.out.println("content = " + content);
+        Clipboard.getSystemClipboard().setContent(content);
     }
-    
 }

--- a/src/main/java/com/github/idelstak/ikonx/view/LocalClipboard.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/LocalClipboard.java
@@ -21,20 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.github.idelstak.ikonx.icons;
+package com.github.idelstak.ikonx.view;
 
-import org.kordamp.ikonli.*;
 
-public record PackIkon(Pack pack, Ikon ikon) {
+public interface LocalClipboard {
 
-    @Override
-    public String toString() {
-        var sb = new StringBuilder();
-        sb.append('{');
-        sb.append(pack);
-        sb.append(", ").append(ikon.getDescription());
-        sb.append('}');
-        return sb.toString();
-    }
-    
+    void copy(String text);
+
 }

--- a/src/test/java/com/github/idelstak/ikonx/mvu/UpdateTest.java
+++ b/src/test/java/com/github/idelstak/ikonx/mvu/UpdateTest.java
@@ -39,7 +39,7 @@ final class UpdateTest {
         var state = ViewState.initial();
         var next = update.apply(state, new Action.SearchChanged("αβ"));
 
-        assertThat(next.searchText(), is("αβ"));
+        assertThat(next.state().searchText(), is("αβ"));
     }
 
     @Test
@@ -50,7 +50,7 @@ final class UpdateTest {
 
         var next = update.apply(state, new Action.SearchChanged("αβ"));
 
-        assertThat(next.status(), instanceOf(ActivityState.Idle.class));
+        assertThat(next.state().status(), instanceOf(ActivityState.Idle.class));
     }
 
     @Test
@@ -64,7 +64,7 @@ final class UpdateTest {
           new Action.PackToggled(pack, true)
         );
 
-        assertThat(next.selectedPacks(), hasItem(pack));
+        assertThat(next.state().selectedPacks(), hasItem(pack));
     }
 
     @Test
@@ -79,7 +79,7 @@ final class UpdateTest {
           new Action.PackToggled(pack, false)
         );
 
-        assertThat(next.selectedPacks(), not(hasItem(pack)));
+        assertThat(next.state().selectedPacks(), not(hasItem(pack)));
     }
 
     @Test
@@ -92,7 +92,7 @@ final class UpdateTest {
           new Action.SelectAllToggled(true)
         );
 
-        assertThat(next.selectedPacks(), hasSize(Pack.values().length));
+        assertThat(next.state().selectedPacks(), hasSize(Pack.values().length));
     }
 
     @Test
@@ -108,7 +108,7 @@ final class UpdateTest {
         var ordered = Arrays.stream(Pack.values())
           .sorted(Comparator.comparing(Enum::name))
           .toList();
-        assertThat(next.selectedPacks(), is(Set.of(ordered.getFirst())));
+        assertThat(next.state().selectedPacks(), is(Set.of(ordered.getFirst())));
     }
 
     @Test
@@ -121,7 +121,7 @@ final class UpdateTest {
           new Action.IconCopied("λ")
         );
 
-        assertThat(next.status(), instanceOf(ActivityState.Success.class));
+        assertThat(next.state().status(), instanceOf(ActivityState.Success.class));
     }
 
     @Test
@@ -135,7 +135,7 @@ final class UpdateTest {
         );
 
         assertThat(
-          next.statusMessage(),
+          next.state().statusMessage(),
           is("Copied 'λ' to clipboard")
         );
     }
@@ -150,6 +150,6 @@ final class UpdateTest {
           new Action.SearchChanged("αβ")
         );
 
-        assertThat(next.displayedIcons(), is(empty()));
+        assertThat(next.state().displayedIcons(), is(empty()));
     }
 }


### PR DESCRIPTION
The state update logic is refactored to separate pure state transitions from side effects. The `Update` function now returns an `UpdateResult` containing both the new state and an optional `Effect` (e.g., `CopyToClipboard`).

The `IconView` subscribes to these effects separately from state updates, allowing for cleaner, more testable code. Clipboard functionality is now abstracted behind an interface to support testing.