### PR TITLE
Refactor side effects to reactive stream

### DIFF
--- a/src/main/java/com/github/idelstak/ikonx/Ikonx.java
+++ b/src/main/java/com/github/idelstak/ikonx/Ikonx.java
@@ -35,7 +35,7 @@ public class Ikonx extends Application {
     @Override
     public void start(Stage primaryStage) throws Exception {
         var loader = new FXMLLoader(getClass().getResource("/fxml/icon-view.fxml"));
-        loader.setControllerFactory(_ -> new IconView(new StateFlow()));
+        loader.setControllerFactory(_ -> new IconView(new StateFlow(new IconClipboard())));
         var root = loader.<Parent>load();
         var scene = new Scene(root);
 

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Effect.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Effect.java
@@ -23,7 +23,7 @@
  */
 package com.github.idelstak.ikonx.mvu;
 
-public sealed interface Effect permits Effect.CopyToClipboard {
+public sealed interface Effect {
 
     record CopyToClipboard(String text) implements Effect {
 

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Flow.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Flow.java
@@ -24,11 +24,12 @@
 package com.github.idelstak.ikonx.mvu;
 
 import com.github.idelstak.ikonx.mvu.action.*;
+import com.github.idelstak.ikonx.mvu.state.*;
 import io.reactivex.rxjava3.core.*;
 
 public interface Flow {
 
     void accept(Action action);
 
-    Observable<UpdateResult> observe();
+    Observable<ViewState> observe();
 }

--- a/src/main/java/com/github/idelstak/ikonx/mvu/Update.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/Update.java
@@ -49,18 +49,20 @@ public final class Update {
           .toList();
     }
 
-    public UpdateResult apply(ViewState state, Action action) {
+    public ViewState apply(ViewState state, Action action) {
         return switch (action) {
             case Action.SearchChanged a ->
-                new UpdateResult(search(state, a), Optional.empty());
+                search(state, a);
             case Action.PackToggled a ->
-                new UpdateResult(toggle(state, a), Optional.empty());
+                toggle(state, a);
             case Action.SelectAllToggled a ->
-                new UpdateResult(toggleAll(state, a), Optional.empty());
-//            case Action.IconCopied a ->
-//                new UpdateResult(copy(state, a), Optional.empty());
-            case Action.IconCopied a ->
-                new UpdateResult(copy(state, a), Optional.of(new Effect.CopyToClipboard(a.iconCode())));
+                toggleAll(state, a);
+            case Action.CopyIconRequested a ->
+                copyRequested(state, a);
+            case Action.CopyIconSucceeded a ->
+                copySucceeded(state, a);
+            case Action.CopyIconFailed a ->
+                copyFailed(state, a);
         };
     }
 
@@ -107,10 +109,22 @@ public final class Update {
           .message(String.format("%d icons found", icons.size()));
     }
 
-    private ViewState copy(ViewState state, Action.IconCopied action) {
+    private ViewState copyRequested(ViewState state, Action.CopyIconRequested action) {
+        return state
+          .signal(new ActivityState.Idle())
+          .message("Copying '" + action.iconCode() + "' to clipboard");
+    }
+
+    private ViewState copySucceeded(ViewState state, Action.CopyIconSucceeded action) {
         return state
           .signal(new ActivityState.Success())
           .message("Copied '" + action.iconCode() + "' to clipboard");
+    }
+
+    private ViewState copyFailed(ViewState state, Action.CopyIconFailed action) {
+        return state
+          .signal(new ActivityState.Error())
+          .message("Failed to copy '" + action.iconCode() + "' to clipboard: " + action.error().getMessage());
     }
 
     private List<PackIkon> filterIcons(Set<Pack> selectedPacks, String searchText) {

--- a/src/main/java/com/github/idelstak/ikonx/mvu/action/Action.java
+++ b/src/main/java/com/github/idelstak/ikonx/mvu/action/Action.java
@@ -39,7 +39,15 @@ public sealed interface Action {
 
     }
 
-    record IconCopied(String iconCode) implements Action {
+    record CopyIconRequested(String iconCode) implements Action {
+
+    }
+
+    record CopyIconSucceeded(String iconCode) implements Action {
+
+    }
+
+    record CopyIconFailed(String iconCode, Throwable error) implements Action {
 
     }
 }

--- a/src/main/java/com/github/idelstak/ikonx/view/FontIconCell.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/FontIconCell.java
@@ -66,14 +66,14 @@ final class FontIconCell extends TableCell<List<PackIkon>, PackIkon> {
 
             root.setOnMouseClicked(event -> {
                 if (event.getClickCount() == 1) {
-                    dispatch.accept(new Action.IconCopied(packIkon.ikon().getDescription()));
+                    dispatch.accept(new Action.CopyIconRequested(packIkon.ikon().getDescription()));
                 }
             });
 
             var contextMenu = new ContextMenu();
             var copyItem = new MenuItem("Copy icon code");
             copyItem.setOnAction(_ ->
-              dispatch.accept(new Action.IconCopied(packIkon.ikon().getDescription())));
+              dispatch.accept(new Action.CopyIconRequested(packIkon.ikon().getDescription())));
             contextMenu.getItems().add(copyItem);
             root.setContextMenu(contextMenu);
 

--- a/src/main/java/com/github/idelstak/ikonx/view/IconClipboard.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/IconClipboard.java
@@ -31,7 +31,6 @@ public final class IconClipboard implements LocalClipboard {
     public void copy(String text) {
         var content = new ClipboardContent();
         content.putString(text);
-        System.out.println("content = " + content);
         Clipboard.getSystemClipboard().setContent(content);
     }
 }

--- a/src/main/java/com/github/idelstak/ikonx/view/IconView.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/IconView.java
@@ -41,10 +41,8 @@ import org.pdfsam.rxjavafx.schedulers.*;
 public class IconView {
 
     private final Flow stateFlow;
-    private final LocalClipboard iconClipboard;
     private final ListChangeListener<Pack> checkedListener;
     private Disposable actionsSubscription;
-    private Disposable clipboardSubscription;
     @FXML
     private SearchTextField searchField;
     @FXML
@@ -59,12 +57,7 @@ public class IconView {
     private StatusBar statusBar;
 
     public IconView(Flow stateFlow) {
-        this(stateFlow, new IconClipboard());
-    }
-
-    public IconView(Flow stateFlow, LocalClipboard iconClipboard) {
         this.stateFlow = stateFlow;
-        this.iconClipboard = iconClipboard;
 
         checkedListener = change -> {
             while (change.next()) {
@@ -111,9 +104,6 @@ public class IconView {
         if (actionsSubscription != null && !actionsSubscription.isDisposed()) {
             actionsSubscription.dispose();
         }
-        if (clipboardSubscription != null && !clipboardSubscription.isDisposed()) {
-            clipboardSubscription.dispose();
-        }
     }
 
     @FXML
@@ -125,18 +115,7 @@ public class IconView {
         setupPackCombo();
         setupEventHandlers();
 
-        actionsSubscription = stateFlow.observe()
-          .observeOn(JavaFxScheduler.platform())
-          .map(UpdateResult::state)
-          .subscribe(this::render);
-        clipboardSubscription = stateFlow.observe()
-          .map(UpdateResult::effect)
-          .filter(Optional::isPresent)
-          .map(Optional::get)
-          .ofType(Effect.CopyToClipboard.class)
-          .observeOn(JavaFxScheduler.platform())
-          .map(Effect.CopyToClipboard::text)
-          .subscribe(iconClipboard::copy);
+        actionsSubscription = stateFlow.observe().observeOn(JavaFxScheduler.platform()).subscribe(this::render);
     }
 
     private void updateTableItemsPreserveSelection(List<List<PackIkon>> partitioned) {

--- a/src/test/java/com/github/idelstak/ikonx/mvu/UpdateTest.java
+++ b/src/test/java/com/github/idelstak/ikonx/mvu/UpdateTest.java
@@ -39,7 +39,7 @@ final class UpdateTest {
         var state = ViewState.initial();
         var next = update.apply(state, new Action.SearchChanged("αβ"));
 
-        assertThat(next.state().searchText(), is("αβ"));
+        assertThat(next.searchText(), is("αβ"));
     }
 
     @Test
@@ -50,7 +50,7 @@ final class UpdateTest {
 
         var next = update.apply(state, new Action.SearchChanged("αβ"));
 
-        assertThat(next.state().status(), instanceOf(ActivityState.Idle.class));
+        assertThat(next.status(), instanceOf(ActivityState.Idle.class));
     }
 
     @Test
@@ -64,7 +64,7 @@ final class UpdateTest {
           new Action.PackToggled(pack, true)
         );
 
-        assertThat(next.state().selectedPacks(), hasItem(pack));
+        assertThat(next.selectedPacks(), hasItem(pack));
     }
 
     @Test
@@ -79,7 +79,7 @@ final class UpdateTest {
           new Action.PackToggled(pack, false)
         );
 
-        assertThat(next.state().selectedPacks(), not(hasItem(pack)));
+        assertThat(next.selectedPacks(), not(hasItem(pack)));
     }
 
     @Test
@@ -92,7 +92,7 @@ final class UpdateTest {
           new Action.SelectAllToggled(true)
         );
 
-        assertThat(next.state().selectedPacks(), hasSize(Pack.values().length));
+        assertThat(next.selectedPacks(), hasSize(Pack.values().length));
     }
 
     @Test
@@ -108,7 +108,7 @@ final class UpdateTest {
         var ordered = Arrays.stream(Pack.values())
           .sorted(Comparator.comparing(Enum::name))
           .toList();
-        assertThat(next.state().selectedPacks(), is(Set.of(ordered.getFirst())));
+        assertThat(next.selectedPacks(), is(Set.of(ordered.getFirst())));
     }
 
     @Test
@@ -118,10 +118,10 @@ final class UpdateTest {
 
         var next = update.apply(
           state,
-          new Action.IconCopied("λ")
+          new Action.CopyIconSucceeded("λ")
         );
 
-        assertThat(next.state().status(), instanceOf(ActivityState.Success.class));
+        assertThat(next.status(), instanceOf(ActivityState.Success.class));
     }
 
     @Test
@@ -131,12 +131,12 @@ final class UpdateTest {
 
         var next = update.apply(
           state,
-          new Action.IconCopied("λ")
+          new Action.CopyIconRequested("λ")
         );
 
         assertThat(
-          next.state().statusMessage(),
-          is("Copied 'λ' to clipboard")
+          next.statusMessage(),
+          is("Copying 'λ' to clipboard")
         );
     }
 
@@ -150,6 +150,6 @@ final class UpdateTest {
           new Action.SearchChanged("αβ")
         );
 
-        assertThat(next.state().displayedIcons(), is(empty()));
+        assertThat(next.displayedIcons(), is(empty()));
     }
 }

--- a/src/test/java/com/github/idelstak/ikonx/view/IconViewTest.java
+++ b/src/test/java/com/github/idelstak/ikonx/view/IconViewTest.java
@@ -69,7 +69,7 @@ final class IconViewTest {
 
         assertEquals(
           "Café",
-          flow.probeResult().state().searchText()
+          flow.probeState().searchText()
         );
     }
 
@@ -81,7 +81,7 @@ final class IconViewTest {
         robot.clickOn("#searchField").write("über");
 
         assertTrue(
-          flow.probeResult().state().displayedIcons().isEmpty()
+          flow.probeState().displayedIcons().isEmpty()
         );
     }
 
@@ -117,8 +117,8 @@ final class IconViewTest {
         var flow = launch(robot, fakeClipboard::set);
         robot.clickOn("#selectAllToggle");
 
-        var result = flow.probeResult();
-        assertEquals(result.state().selectedPacks().size(), Pack.values().length);
+        var result = flow.probeState();
+        assertEquals(result.selectedPacks().size(), Pack.values().length);
     }
 
     @Test
@@ -147,7 +147,7 @@ final class IconViewTest {
         robot.clickOn("bi-alarm");
 
         var lastAction = flow.probeLastAfter(before);
-        Action.IconCopied action = (Action.IconCopied) lastAction.orElseThrow();
+        Action.CopyIconSucceeded action = (Action.CopyIconSucceeded) lastAction.orElseThrow();
 
         assertThat(action.iconCode(), is("bi-alarm"));
     }
@@ -224,18 +224,18 @@ final class IconViewTest {
 
         var expected = Pack.BOOTSTRAP.getIkons()[Pack.BOOTSTRAP.getIkons().length - 1].getDescription();
         robot.clickOn(expected);
-
+        
         assertThat(fakeClipboard.get(), is(expected));
     }
 
     private FlowProbe launch(FxRobot robot, Consumer<String> copyCallback) throws Exception {
-        var flow = new FlowProbe();
         LocalClipboard testClipboard = copyCallback::accept;
+        var flow = new FlowProbe(testClipboard);
         robot.interact(() -> {
             var loader = new FXMLLoader(
               Ikonx.class.getResource("/fxml/icon-view.fxml")
             );
-            loader.setControllerFactory(_ -> new IconView(flow, testClipboard));
+            loader.setControllerFactory(_ -> new IconView(flow));
             Parent root;
             try {
                 root = loader.load();


### PR DESCRIPTION
Move side effect handling into a reactive stream within `StateFlow`. Actions that trigger side effects, like copying to the clipboard, now have corresponding success and failure actions. This makes the application more resilient and easier to debug. The clipboard logic is now handled asynchronously, and the UI is updated based on the outcome of the operation.