### PR TITLE
Refactor `IconView` into smaller, focused classes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## Why IkonX Exists
 
-Finding the right icon for your JavaFX project can be a hassle. I know the struggle. See, there are more than 6000 icons spread across 55 different icon packs in [Ikonli](https://github.com/kordamp/ikonli). That's a lot of icon codes to comb through!
+Finding the right icon for your JavaFX project can be a hassle. I know the struggle. See, there are more than 45,000 icons spread across 55 different icon packs in [Ikonli](https://github.com/kordamp/ikonli). That's a lot of icon codes to comb through!
 
 I was inspired by the [AltantaFX sampler](https://downloads.hydraulic.dev/atlantafx/sampler/download.html), which made browsing Material icons a breeze. So, I decided to take it a step further. I created IkonX - the Icon Pack Browser. With this tool, you can easily search, preview, and copy icon codes from **all** available icon packs. No more digging through endless documents to find that perfect icon.
 
@@ -17,6 +17,40 @@ Here's what you can do with IkonX:
 - **Preview Icons:** See what each icon looks like before you choose.
 - **Copy and Paste:** Click an icon, and its code is automatically copied to your clipboard.
 - **User-Friendly:** It's simple and easy to use.
+
+## Architecture: Model-View-Update (MVU)
+
+IkonX follows a strict Model-View-Update (MVU) architecture, enforcing **unidirectional data flow** and a **single source of truth**.
+
+### Core Principles
+
+1. **Single Source of Truth**: The entire application state is stored in a single `ViewState` object. The UI is a pure function of this state.
+
+2. **Unidirectional Data Flow**: Data flows in one direction:
+
+   * **Action**: User interactions and other events are represented as immutable `Action` objects.
+   * **State**: The `Update` function takes the current `ViewState` and an `Action` and produces a new `ViewState`.
+   * **View**: The `IconView` observes the `ViewState` and updates the UI accordingly.
+
+3. **No Direct UI Mutation**: The UI is never mutated directly. All changes are the result of a new `ViewState` being emitted. The `render(ViewState)` method in `IconView` is the only place where the UI is updated.
+
+### The Flow
+
+```mermaid
+flowchart LR
+    UI[UI] -->|Dispatch Action| Action[Action]
+    Action -->|Processed by| Update[Update Function]
+    Update -->|Produces| ViewState[ViewState]
+    ViewState -->|Observed by| IconView[IconView]
+    IconView -->|Re-renders UI| UI
+```
+
+1. The UI dispatches an `Action`.
+2. The `Action` is sent to the `Update` function.
+3. The `Update` function produces a new `ViewState`.
+4. The `IconView` receives the new `ViewState` and re-renders itself.
+
+This strict adherence to MVU results in a predictable, testable, and maintainable codebase.
 
 ## Getting Started with IkonX
 

--- a/src/main/java/com/github/idelstak/ikonx/view/PackSelectionView.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/PackSelectionView.java
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Hiram K
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.idelstak.ikonx.view;
+
+import com.github.idelstak.ikonx.icons.*;
+import com.github.idelstak.ikonx.mvu.action.*;
+import java.util.*;
+import java.util.function.*;
+import javafx.collections.*;
+import org.controlsfx.control.*;
+
+final class PackSelectionView {
+
+    private final CheckComboBox<Pack> combo;
+    private final ListChangeListener<Pack> listener;
+
+    PackSelectionView(CheckComboBox<Pack> combo, Consumer<Action> actions) {
+        this.combo = combo;
+        this.listener = change -> {
+            while (change.next()) {
+                for (var pack : change.getRemoved()) {
+                    actions.accept(new Action.PackToggled(pack, false));
+                }
+                for (var pack : change.getAddedSubList()) {
+                    actions.accept(new Action.PackToggled(pack, true));
+                }
+            }
+        };
+        combo.getCheckModel().getCheckedItems().addListener(listener);
+    }
+
+    void render(Set<Pack> selected) {
+        var model = combo.getCheckModel();
+        model.getCheckedItems().removeListener(listener);
+        try {
+            for (var pack : combo.getItems()) {
+                if (selected.contains(pack)) {
+                    model.check(pack);
+                } else {
+                    model.clearCheck(pack);
+                }
+            }
+        } finally {
+            model.getCheckedItems().addListener(listener);
+        }
+    }
+}

--- a/src/main/java/com/github/idelstak/ikonx/view/TableSelectionFix.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/TableSelectionFix.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Hiram K
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.idelstak.ikonx.view;
+
+import com.github.idelstak.ikonx.icons.*;
+import java.util.*;
+import javafx.scene.control.*;
+
+final class TableSelectionFix {
+
+    private final TableView<List<PackIkon>> table;
+
+    TableSelectionFix(TableView<List<PackIkon>> table) {
+        this.table = table;
+    }
+
+    void render(Runnable itemsUpdate) {
+        var sm = table.getSelectionModel();
+        var selected = sm.getSelectedCells().isEmpty() ? null : sm.getSelectedCells().get(0);
+        
+        itemsUpdate.run();
+        
+        if (selected != null) {
+            var row = selected.getRow();
+            var col = selected.getColumn();
+            if (row < table.getItems().size() && col < table.getColumns().size()) {
+                sm.clearSelection();
+                sm.select(row, table.getColumns().get(col));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Decompose the `IconView` class into smaller, single-responsibility classes to improve modularity and clarity. The logic for managing the pack selection combo box is now encapsulated in `PackSelectionView`, and the workaround for preserving table selection is in `TableSelectionFix`.

Update the `readme.md` to include a detailed explanation of the Model-View-Update (MVU) architecture used in the application.