### PR TITLE
Simplify Maven caching in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,7 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ needs.extract.outputs.java_version }}
-
-      - name: Cache Maven repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-${{ runner.os }}-
+          cache: maven
 
       - name: Determine platform name
         id: platform


### PR DESCRIPTION
Replaces the manual `actions/cache` step with the integrated `cache: maven` option in the `setup-java` action. This simplifies the workflow configuration and improves maintainability.