### PR TITLE
Add icon details panel and update theme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Finding the right icon for your JavaFX project can be a hassle. I know the strug
 
 I was inspired by the [AltantaFX sampler](https://downloads.hydraulic.dev/atlantafx/sampler/download.html), which made browsing Material icons a breeze. So, I decided to take it a step further. I created IkonX - the Icon Pack Browser. With this tool, you can easily search, preview, and copy icon codes from **all** available icon packs. No more digging through endless documents to find that perfect icon.
 
-![Screenshot](assets/img.png)
+![Screencast](assets/showcase-big.gif)
 
 ## What IkonX Does
 

--- a/src/main/java/com/github/idelstak/ikonx/Ikonx.java
+++ b/src/main/java/com/github/idelstak/ikonx/Ikonx.java
@@ -48,7 +48,7 @@ public class Ikonx extends Application {
         var flow = new StateFlow(new IconClipboard(), meta);
 
         loader.setControllerFactory(type -> {
-            System.out.println("[IKONX] type = " + type.getSimpleName());
+            System.out.println("[IKONX] init view: " + type.getSimpleName());
             try {
                 if (type == IkonxView.class) {
                     return new IkonxView(primaryStage, flow);
@@ -67,6 +67,9 @@ public class Ikonx extends Application {
                 }
                 if (type == OverlayView.class) {
                     return new OverlayView(primaryStage, flow);
+                }
+                if (type == IconDetailsView.class) {
+                    return new IconDetailsView(primaryStage, flow);
                 }
                 if (type == PacksFilterView.class) {
                     return new PacksFilterView(primaryStage, flow);

--- a/src/main/java/com/github/idelstak/ikonx/view/HeaderView.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/HeaderView.java
@@ -32,6 +32,7 @@ import io.reactivex.rxjava3.disposables.*;
 import java.net.*;
 import java.util.*;
 import javafx.application.*;
+import javafx.collections.*;
 import javafx.fxml.*;
 import javafx.scene.control.*;
 import javafx.scene.text.*;
@@ -48,7 +49,7 @@ public class HeaderView implements Initializable {
     @FXML
     private Tooltip toggleViewTip;
     @FXML
-    private ComboBox<?> copyFormatComboBox;
+    private ComboBox<String> copyFormatComboBox;
     @FXML
     private TextField searchInput;
     @FXML
@@ -69,6 +70,7 @@ public class HeaderView implements Initializable {
     public void initialize(URL location, ResourceBundle resources) {
         setupStage();
         setupActionsSubscription();
+        setupCopyFormat();
         setupViewToggle();
         setupSearchInput();
         setupFilterButton();
@@ -84,6 +86,11 @@ public class HeaderView implements Initializable {
         });
     }
 
+    private void setupCopyFormat() {
+        copyFormatComboBox.setItems(FXCollections.observableArrayList("Icon code"));
+        Platform.runLater(copyFormatComboBox.getSelectionModel()::selectFirst);
+    }
+
     private void setupViewToggle() {
         toggleViewButton.setOnAction(_ -> flow.accept(new Action.ViewModeToggled()));
     }
@@ -97,6 +104,8 @@ public class HeaderView implements Initializable {
                 flow.accept(new Action.SearchCleared());
             }
         });
+        
+        Platform.runLater(searchInput::requestFocus);
 
         clearButton.setOnAction(_ -> flow.accept(new Action.SearchCleared()));
     }
@@ -126,7 +135,7 @@ public class HeaderView implements Initializable {
 
         var iconsCount = state.displayedIkons().size();
         searchInput.setPromptText("Search %d icons...".formatted(iconsCount));
-        
+
         var isSearching = state.query() instanceof IkonQuery.Searching;
         if (!isSearching) {
             searchInput.clear();

--- a/src/main/java/com/github/idelstak/ikonx/view/InnerMainView.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/InnerMainView.java
@@ -104,7 +104,7 @@ public class InnerMainView implements Initializable {
 
         switch (detailsDisplay) {
             case IkonDetailsDisplay.ShowRequested _ -> {
-                var blur = new GaussianBlur(15); // intensity of blur
+                var blur = new GaussianBlur(7); // intensity of blur
                 innerMainLayout.setEffect(blur);
             }
             case IkonDetailsDisplay.HideRequested _ -> {

--- a/src/main/java/com/github/idelstak/ikonx/view/PacksFilterView.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/PacksFilterView.java
@@ -37,7 +37,7 @@ import javafx.scene.layout.*;
 import javafx.stage.*;
 import org.pdfsam.rxjavafx.schedulers.*;
 
-public class PacksFilterView implements Initializable {
+public final class PacksFilterView implements Initializable {
 
     private final Stage stage;
     private final Flow flow;
@@ -61,16 +61,7 @@ public class PacksFilterView implements Initializable {
         setupStage();
         setupActionsSubscription();
         setupToggleAllButton();
-
-//        filterDropdown.parentProperty().addListener((obs, oldVal, newVal) -> {
-//            if (newVal != null) {
-//                newVal.setOnMouseClicked(event -> {
-//                    if (!filterDropdown.getBoundsInParent().contains(event.getX(), event.getY())) {
-//                        flow.accept(new Action.FilterPacksRequested());
-//                    }
-//                });
-//            }
-//        });
+        setupHideOnClick();
     }
 
     private void setupStage() {
@@ -79,12 +70,6 @@ public class PacksFilterView implements Initializable {
             Platform.exit();
             System.exit(0);
         });
-    }
-
-    private void dispose() {
-        if (subscription != null && !subscription.isDisposed()) {
-            subscription.dispose();
-        }
     }
 
     private void setupActionsSubscription() {
@@ -97,9 +82,21 @@ public class PacksFilterView implements Initializable {
         toggleAllButton.setOnAction(_ -> flow.accept(new Action.SelectAllPacksToggled()));
     }
 
+    private void setupHideOnClick() {
+        filterDropdown.parentProperty().addListener((_, _, parent) -> {
+            if (parent != null) {
+                parent.setOnMouseClicked(event -> {
+                    if (!filterDropdown.getBoundsInParent().contains(event.getX(), event.getY())) {
+                        flow.accept(new Action.FilterPacksSucceeded());
+                    }
+                });
+            }
+        });
+    }
+
     private void render(ViewState state) {
         var filter = state.filter();
-
+        
         if (filter instanceof PacksFilter.Show) {
             filterDropdown.setVisible(true);
             filterDropdown.setManaged(true);
@@ -155,5 +152,11 @@ public class PacksFilterView implements Initializable {
                    ? new Action.SelectAllPackStylesToggled()
                    : new Action.PackStyleToggled(style);
         flow.accept(action);
+    }
+
+    private void dispose() {
+        if (subscription != null && !subscription.isDisposed()) {
+            subscription.dispose();
+        }
     }
 }

--- a/src/main/java/com/github/idelstak/ikonx/view/SidebarView.java
+++ b/src/main/java/com/github/idelstak/ikonx/view/SidebarView.java
@@ -101,7 +101,6 @@ public class SidebarView implements Initializable {
             var button = new Button();
             button.getStyleClass().add("favorite-button");
             button.setOnAction(_ -> {
-                System.out.println("Show details for: " + favorite.description());
                 flow.accept(new Action.ViewIkonDetailsRequested(favorite));
             });
 
@@ -129,7 +128,6 @@ public class SidebarView implements Initializable {
         Button historyItem = new Button();
         historyItem.getStyleClass().add("history-item");
         historyItem.setOnAction(_ -> {
-            System.out.println("Show details for: " + ikon.description());
             flow.accept(new Action.ViewIkonDetailsRequested(ikon));
         });
 

--- a/src/main/resources/fxml/icon-details.fxml
+++ b/src/main/resources/fxml/icon-details.fxml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
 
     The MIT License
@@ -29,8 +30,9 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.shape.*?>
+<?import org.kordamp.ikonli.javafx.*?>
 
-<VBox styleClass="details-panel" visible="false" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.idelstak.ikonx.view.IconDetailsView">
+<VBox fx:id="detailsRoot" styleClass="details-panel" xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.github.idelstak.ikonx.view.IconDetailsView">
    <stylesheets>
       <URL value="@../styles/fonts.css" />
       <URL value="@../styles/ikonx-root.css" />
@@ -48,28 +50,35 @@
                            <SVGPath content="M18,6 L6,18 M6,6 L18,18" styleClass="close-icon" />
                         </StackPane>
                      </graphic>
+               <tooltip>
+                  <Tooltip text="Close" />
+               </tooltip>
                   </Button>
                </children>
             </HBox>
             <!-- Content -->
             <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" styleClass="content-scroll-pane" VBox.vgrow="ALWAYS">
                <content>
-                   <VBox fx:id="detailsContentBox" styleClass="content-box">
+                   <VBox styleClass="content-box">
                        <!-- Icon Display -->
     <VBox spacing="8" styleClass="icon-display-box">
-        <Region fx:id="iconPreview" styleClass="icon-preview" />
+                  <StackPane styleClass="icon-preview">
+                     <children>
+                        <FontIcon fx:id="icon" />
+                     </children>
+                  </StackPane>
         <Label fx:id="title" styleClass="icon-title" text="{title}" />
         <Label fx:id="subtitle" styleClass="icon-subtitle" text="{subtitle}" />
     </VBox>
 
     <!-- Info Section -->
-    <VBox fx:id="infoBox" spacing="16">
+    <VBox spacing="16">
                   <children>
                      <HBox styleClass="info-row">
                         <children>
                            <Label styleClass="info-label" text="Pack" />
                            <Region maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS" />
-                           <Label text="{pack name}">
+                           <Label fx:id="packLabel" text="{pack name}">
                               <styleClass>
                                  <String fx:value="info-value" />
                                  <String fx:value="tag-neutral" />
@@ -81,7 +90,7 @@
                         <children>
                            <Label styleClass="info-label" text="License" />
                            <Region maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS" />
-                           <Label text="{license name}">
+                           <Label fx:id="licenseLabel" text="{license name}">
                               <styleClass>
                                  <String fx:value="info-value" />
                                  <String fx:value="tag-emerald" />
@@ -93,7 +102,7 @@
                         <children>
                            <Label styleClass="info-label" text="Author" />
                            <Region maxWidth="1.7976931348623157E308" HBox.hgrow="ALWAYS" />
-                           <Label styleClass="info-value" text="{author name}" />
+                           <Label fx:id="authorLabel" styleClass="info-value" text="{author name}" />
                         </children>
                      </HBox>
                   </children></VBox>

--- a/src/main/resources/styles/header.css
+++ b/src/main/resources/styles/header.css
@@ -37,7 +37,7 @@
     -fx-spacing: 12px
 }
 .logo-icon-wrapper {
-    -fx-background-color: #4f46e5;
+    -fx-background-color: #0b57d0;
     -fx-padding: 8px;
     -fx-background-radius: 8px
 }
@@ -77,7 +77,7 @@
 /* Corresponds to: focus:bg-white focus:ring-2 focus:ring-indigo-500 */
 .icon-button:focused {
     -fx-background-color: white;
-    -fx-border-color: #6366f1; /* indigo-500 */
+    -fx-border-color: #0b57d0; /* indigo-500 */
 }
 .icon-button:hover {
     -fx-background-color: #f3f4f6
@@ -117,30 +117,15 @@
 /* Corresponds to: focus:bg-white focus:ring-2 focus:ring-indigo-500 */
 .copy-format-combo:focused {
     -fx-background-color: white;
-    -fx-border-color: #6366f1; /* indigo-500 */
+    -fx-border-color: #0b57d0; /* indigo-500 */
 }
 .copy-format-combo:focused .arrow-button {
     -fx-effect: dropshadow(gaussian, rgba(79, 70, 229, 0.5), 10, 0, 0, 0)
 }
 .search-bar {
-    /*    -fx-background-color: #f3f4f6;
-        -fx-background-radius: 8px;
-        -fx-border-radius: 8px;
-        -fx-border-width: 2px;
-        -fx-border-color: transparent;
-        -fx-alignment: CENTER_LEFT;*/
     -fx-pref-height: 40px;
     -fx-max-width: 'Infinity'
 }
-/*.search-bar:focused-within {
-    -fx-background-color: white;
-    -fx-border-color: #4f46e5
-}*/
-/*.search-bar-icon {
-    -fx-icon-size: 16px;
-    -fx-icon-color: #9ca3af;
-    -fx-padding: 0 0 0 12px
-}*/
 .search-input {
     /*    -fx-background-color: transparent;
         -fx-font-size: 14px;
@@ -171,7 +156,7 @@
 /* Corresponds to: focus:bg-white focus:ring-2 focus:ring-indigo-500 */
 .search-input:focused {
     -fx-background-color: white;
-    -fx-border-color: #6366f1; /* indigo-500 */
+    -fx-border-color: #0b57d0; /* indigo-500 */
 }
 
 /* --- ICONS --- */
@@ -238,7 +223,7 @@
 /* Corresponds to: focus:bg-white focus:ring-2 focus:ring-indigo-500 */
 .filter-button:focused {
     -fx-background-color: white;
-    -fx-border-color: #6366f1; /* indigo-500 */
+    -fx-border-color: #0b57d0; /* indigo-500 */
 }
 .filter-button-graphic {
     -fx-alignment: CENTER_LEFT;

--- a/src/main/resources/styles/icon-details.css
+++ b/src/main/resources/styles/icon-details.css
@@ -69,10 +69,11 @@
     -fx-min-height: 80px;
     -fx-max-width: 80px;
     -fx-max-height: 80px;
-    -fx-border-color: #4f46e5;
-    -fx-border-width: 4px;
-    -fx-border-radius: 12px;
-    -fx-margin: 0 0 16px 0
+    -fx-margin: 0 0 18px 0
+}
+.icon-preview .ikonli-font-icon {
+    -fx-icon-size: 54px;
+    -fx-icon-color: derive(#d4d4d4, -60%);
 }
 .icon-title {
     -fx-font-family: 'Inter bold';
@@ -107,14 +108,15 @@
     -fx-spacing: 12px
 }
 .copy-button {
-    -fx-background-color: #4f46e5;
+    -fx-background-color: #0b57d0;
     -fx-text-fill: white;
     -fx-background-radius: 12px;
     -fx-font-family: 'Inter bold';
     -fx-padding: 12px;
     -fx-font-size: 14px;
-    -fx-effect: dropshadow(gaussian, rgba(79, 70, 229, 0.2), 10, 0, 0, 4)
+    -fx-effect: dropshadow(gaussian, rgba(79, 70, 229, 0.2), 10, 0, 0, 4);
+    -fx-cursor: hand;
 }
 .copy-button:hover {
-    -fx-background-color: #4338ca
+    -fx-background-color: derive(#0b57d0, -30%)
 }

--- a/src/main/resources/styles/icon-grid.css
+++ b/src/main/resources/styles/icon-grid.css
@@ -90,7 +90,7 @@
 }
 
 .grid-cell:hover .icon-placeholder {
-    -fx-icon-color: #4f46e5;
+    -fx-icon-color: #0b57d0;
 }
 
 /* --- Text Wrapper --- */
@@ -121,7 +121,7 @@
 
 .grid-cell:hover .icon-name,
 .grid-cell:hover .icon-pack {
-    -fx-text-fill: #4f46e5;
+    -fx-text-fill: #0b57d0;
 }
 
 /* --- Action Buttons --- */
@@ -175,7 +175,7 @@
 }
 
 .action-button:hover .details-icon {
-    -fx-background-color: #4f46e5;
+    -fx-background-color: #0b57d0;
 }
 
 .favorite-icon-unselected,

--- a/src/main/resources/styles/ikonx-root.css
+++ b/src/main/resources/styles/ikonx-root.css
@@ -25,22 +25,27 @@
     -fx-background: #fafafa;
     -fx-control-inner-background: #ffffff;
     -fx-control-inner-background-alt: #f9f9f9;
+
     -fx-dark-text-color: #171717;
     -fx-mid-text-color: #404040;
     -fx-light-text-color: #ffffff;
-    -fx-accent: #4f46e5;
-    -fx-default-button: #e0e7ff;
-    -fx-focus-color: #6366f1;
-    -fx-color: -fx-base;
+
+    -fx-accent: #0b57d0;
+    -fx-focus-color: #0b57d0;
+    -fx-default-button: derive(-fx-accent, 85%);
+
     -fx-selection-bar: -fx-accent;
     -fx-selection-bar-non-focused: #e5e7eb;
-    -fx-cell-hover-color: #eef2ff;
+    -fx-cell-hover-color: derive(-fx-accent, 90%);
+
     -fx-box-border: #e5e5e5;
     -fx-text-box-border: #e5e5e5;
+
     -fx-background-color: -fx-background;
     -fx-font-family: 'Inter';
-    -fx-text-fill: #171717
+    -fx-text-fill: #171717;
 }
+
 .scroll-pane {
     -fx-background-color: transparent
 }

--- a/src/main/resources/styles/packs-filter.css
+++ b/src/main/resources/styles/packs-filter.css
@@ -62,7 +62,7 @@
 .toggle-all-button {
     /* text-xs text-indigo-600 hover:underline */
     -fx-font-size: 12px;
-    -fx-text-fill: #4f46e5;
+    -fx-text-fill: #0b57d0;
     -fx-background-color: transparent;
     -fx-padding: 0;
     -fx-cursor: hand;
@@ -108,11 +108,11 @@
 }
 .pack-checkbox:selected .mark {
     /* text-indigo-600 */
-    -fx-background-color: #4f46e5;
+    -fx-background-color: #0b57d0;
 }
 .pack-checkbox:focused .box {
     /* focus:ring-indigo-500 */
-    -fx-border-color: #6366f1;
+    -fx-border-color: #0b57d0;
     -fx-border-width: 2px;
 }
 
@@ -150,7 +150,7 @@
 
 .style-button:selected {
     /* bg-indigo-600 text-white border-indigo-600 */
-    -fx-background-color: #4f46e5;
+    -fx-background-color: #0b57d0;
     -fx-text-fill: white;
-    -fx-border-color: #4f46e5;
+    -fx-border-color: #0b57d0;
 }

--- a/src/test/java/com/github/idelstak/ikonx/mvu/state/UpdateTest.java
+++ b/src/test/java/com/github/idelstak/ikonx/mvu/state/UpdateTest.java
@@ -814,22 +814,6 @@ final class UpdateTest {
     }
 
     @Test
-    void viewSucceededShowsMessage() {
-        var update = new Update();
-        var state = ViewState.initial();
-
-        var next = update.apply(
-          state,
-          new Action.HideIkonDetailsRequested()
-        );
-
-        assertThat(
-          next.statusMessage(),
-          is("Viewed icon details")
-        );
-    }
-
-    @Test
     void viewFailedSignalsError() {
         var update = new Update();
         var state = ViewState.initial();


### PR DESCRIPTION
Implements a new side panel to display detailed icon information, including pack, license, and author. The panel slides in from the right, blurring the main view for focus.

This update also refreshes the application's visual theme with a new accent color. Additionally, it improves user experience by auto-closing the filter panel when clicking away and setting initial focus to the search bar.